### PR TITLE
LDAModel: Infer topic distributions on previously unseen documents

### DIFF
--- a/src/main/java/nlmt/topicmodels/Document.java
+++ b/src/main/java/nlmt/topicmodels/Document.java
@@ -38,11 +38,14 @@ public class Document
     // topic 3, and "sat" is assigned to topic 2
     private int [] topicArray;
 
+    private String [] rawWords;
+
     // The Vocabulary that provides the mapping from word
     // Strings to numbers
     private Vocabulary vocabulary;
 
     public Document(Vocabulary vocabulary) {
+        this.rawWords = new String[0];
         this.wordArray = new int[0];
         this.topicArray = new int[0];
         this.vocabulary = vocabulary;
@@ -58,8 +61,10 @@ public class Document
     public void readDocument(List<String> words) {
         wordArray = new int[words.size()];
         topicArray = new int[words.size()];
+        rawWords = new String[words.size()];
         int currentIndex = 0;
         for (String word : words) {
+            rawWords[currentIndex] = word;
             vocabulary.addWord(word);
             wordArray[currentIndex] = vocabulary.getIndexFromWord(word);
             topicArray[currentIndex] = -1;
@@ -76,6 +81,10 @@ public class Document
      */
     public int [] getWordArray() {
         return wordArray;
+    }
+
+    public String [] getRawWords() {
+        return rawWords;
     }
 
     /**

--- a/src/main/java/nlmt/topicmodels/Document.java
+++ b/src/main/java/nlmt/topicmodels/Document.java
@@ -87,7 +87,7 @@ public class Document
     public String [] getRawWords() {
         String [] result = new String[wordArray.length];
         for (int wordIndex = 0; wordIndex < wordArray.length; wordIndex++) {
-            result[wordIndex] = vocabulary.getWordFromIndex(wordIndex);
+            result[wordIndex] = vocabulary.getWordFromIndex(wordArray[wordIndex]);
         }
         return result;
     }

--- a/src/main/java/nlmt/topicmodels/Document.java
+++ b/src/main/java/nlmt/topicmodels/Document.java
@@ -38,14 +38,11 @@ public class Document
     // topic 3, and "sat" is assigned to topic 2
     private int [] topicArray;
 
-    private String [] rawWords;
-
     // The Vocabulary that provides the mapping from word
     // Strings to numbers
     private Vocabulary vocabulary;
 
     public Document(Vocabulary vocabulary) {
-        this.rawWords = new String[0];
         this.wordArray = new int[0];
         this.topicArray = new int[0];
         this.vocabulary = vocabulary;
@@ -61,10 +58,8 @@ public class Document
     public void readDocument(List<String> words) {
         wordArray = new int[words.size()];
         topicArray = new int[words.size()];
-        rawWords = new String[words.size()];
         int currentIndex = 0;
         for (String word : words) {
-            rawWords[currentIndex] = word;
             vocabulary.addWord(word);
             wordArray[currentIndex] = vocabulary.getIndexFromWord(word);
             topicArray[currentIndex] = -1;
@@ -83,8 +78,18 @@ public class Document
         return wordArray;
     }
 
+    /**
+     * Returns the original set of strings representing the document
+     * from the vocabulary.
+     *
+     * @return the original array of Strings
+     */
     public String [] getRawWords() {
-        return rawWords;
+        String [] result = new String[wordArray.length];
+        for (int wordIndex = 0; wordIndex < wordArray.length; wordIndex++) {
+            result[wordIndex] = vocabulary.getWordFromIndex(wordIndex);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/nlmt/topicmodels/LDAModel.java
+++ b/src/main/java/nlmt/topicmodels/LDAModel.java
@@ -275,6 +275,23 @@ public class LDAModel
         return documentPMFSampler.getProbabilities();
     }
 
+    /**
+     * Infer what the topic distribution should be for the given document.
+     * Returns an array representing the topics found within the document.
+     * For example, assuming there were 3 topics:
+     *
+     * result[0] = 0.87
+     * result[1] = 0.10
+     * result[2] = 0.03
+     *
+     * This means that the document is composed of 87% of topic 1,
+     * 10% of topic 2, and 3% of topic 3. Words that have not been seen before
+     * by the model are ignored when determining topic distributions.
+     *
+     * @param document the new document to infer
+     * @param numIterations the number of iterations to perform the inference on
+     * @return an array of topic distributions
+     */
     public double [] inference(List<String> document, int numIterations) {
         Vocabulary newVocabulary = new Vocabulary();
         Document newDocument = new Document(newVocabulary);
@@ -302,7 +319,7 @@ public class LDAModel
             }
         }
 
-        // Figure out what the distribution of topics are
+        // Figure out what the distribution of topics should be
         PMFSampler documentPMFSampler = new PMFSampler(numTopics);
         for (int topicIndex = 0; topicIndex < numTopics; topicIndex++) {
             documentPMFSampler.add((((double)localTopicDocumentCount[topicIndex]) + alpha));

--- a/src/main/java/nlmt/topicmodels/Vocabulary.java
+++ b/src/main/java/nlmt/topicmodels/Vocabulary.java
@@ -80,6 +80,10 @@ public class Vocabulary {
         return -1;
     }
 
+    public boolean contains(String word) {
+        return wordIndexMap.containsKey(word);
+    }
+
     /**
      * Bumps the nextIndex counter up by 1.
      */

--- a/src/main/java/nlmt/topicmodels/Vocabulary.java
+++ b/src/main/java/nlmt/topicmodels/Vocabulary.java
@@ -80,6 +80,13 @@ public class Vocabulary {
         return -1;
     }
 
+    /**
+     * Returns <code>true</code> if the Vocabulary contains the specified
+     * word.
+     *
+     * @param word the String word to check
+     * @return <code>true</code> if the word is in the Vocabulary
+     */
     public boolean contains(String word) {
         return wordIndexMap.containsKey(word);
     }

--- a/src/test/java/nlmt/topicmodels/DocumentTest.java
+++ b/src/test/java/nlmt/topicmodels/DocumentTest.java
@@ -124,4 +124,14 @@ public class DocumentTest {
     public void testSetTopicOnNoDocumentThrowsException() {
         document.setTopicForWord(0, 1);
     }
+
+    @Test
+    public void testGetWordsOnDocumentAllSameWord() {
+        String [] words = {"the", "the", "the"};
+        int [] vocabList = {0, 0, 0};
+        document.readDocument(Arrays.asList(words));
+        assertThat(document.getWordArray().length, is(equalTo(3)));
+        assertThat(document.getWordArray(), is(equalTo(vocabList)));
+        assertThat(document.getRawWords(), is(equalTo(words)));
+    }
 }

--- a/src/test/java/nlmt/topicmodels/DocumentTest.java
+++ b/src/test/java/nlmt/topicmodels/DocumentTest.java
@@ -72,6 +72,13 @@ public class DocumentTest {
     }
 
     @Test
+    public void testGetRawWordsWorksCorrectly() {
+        String [] words = {"the", "cat", "sat"};
+        document.readDocument(Arrays.asList(words));
+        assertThat(document.getRawWords(), is(equalTo(words)));
+    }
+
+    @Test
     public void testTopicArrayAllNegativeOnesWhenDocumentRead() {
         String [] words = {"the", "cat", "sat"};
         document.readDocument(Arrays.asList(words));

--- a/src/test/java/nlmt/topicmodels/LDAModelTest.java
+++ b/src/test/java/nlmt/topicmodels/LDAModelTest.java
@@ -514,4 +514,28 @@ public class LDAModelTest {
         ldaModel.initialize();
         ldaModel.getTopicMixtureForDocument(10);
     }
+
+    @Test
+    public void testInferenceOnEmptyDocumentReturnsEmptyProbabilities() {
+        ldaModel = new LDAModel(3);
+        ldaModel.readDocuments(documents);
+        ldaModel.doGibbsSampling(100);
+
+        List<String> emptyDocument = new ArrayList<>();
+        double [] expected = {0.0, 0.0, 0.0};
+        assertThat(ldaModel.inference(emptyDocument, 100), is(equalTo(expected)));
+    }
+
+    @Test
+    public void testInferenceDocumentHasNoWordsMatchingGlobalVocabulary() {
+        ldaModel = new LDAModel(3);
+        ldaModel.readDocuments(documents);
+        ldaModel.doGibbsSampling(100);
+
+        List<String> noGlobalWords = new ArrayList<>();
+        noGlobalWords.add("hello");
+        noGlobalWords.add("world");
+        double [] expected = {0.0, 0.0, 0.0};
+        assertThat(ldaModel.inference(noGlobalWords, 100), is(equalTo(expected)));
+    }
 }

--- a/src/test/java/nlmt/topicmodels/LDAModelTest.java
+++ b/src/test/java/nlmt/topicmodels/LDAModelTest.java
@@ -113,14 +113,14 @@ public class LDAModelTest {
         ldaModel.readDocuments(documents);
         ldaModel.initialize();
 
-        int currentTopicDocumentCount = ldaModel.topicDocumentCount[0][0];
+        int currentDocumentTopicCount = ldaModel.documentTopicCount[0][0];
         int currentWordTopicCount = ldaModel.wordTopicCount[0][0];
         int currentTopicTotals = ldaModel.topicTotals[0];
 
         ldaModel.addTopicToWord(0, 0, 0, 0);
 
         assertThat(ldaModel.documents[0].getTopicArray()[0], is(equalTo(0)));
-        assertThat(ldaModel.topicDocumentCount[0][0], is(equalTo(currentTopicDocumentCount + 1)));
+        assertThat(ldaModel.documentTopicCount[0][0], is(equalTo(currentDocumentTopicCount + 1)));
         assertThat(ldaModel.wordTopicCount[0][0], is(equalTo(currentWordTopicCount + 1)));
         assertThat(ldaModel.topicTotals[0], is(equalTo(currentTopicTotals + 1)));
     }
@@ -131,28 +131,28 @@ public class LDAModelTest {
         ldaModel.readDocuments(documents);
         ldaModel.initialize();
 
-        int currentTopicDocumentCount = ldaModel.topicDocumentCount[0][0];
+        int currentDocumentTopicCount = ldaModel.documentTopicCount[0][0];
         int currentWordTopicCount = ldaModel.wordTopicCount[0][0];
         int currentTopicTotals = ldaModel.topicTotals[0];
 
         ldaModel.removeTopicFromWord(0, 0, 0, 0);
 
         assertThat(ldaModel.documents[0].getTopicArray()[0], is(equalTo(-1)));
-        assertThat(ldaModel.topicDocumentCount[0][0], is(equalTo(currentTopicDocumentCount - 1)));
+        assertThat(ldaModel.documentTopicCount[0][0], is(equalTo(currentDocumentTopicCount - 1)));
         assertThat(ldaModel.wordTopicCount[0][0], is(equalTo(currentWordTopicCount - 1)));
         assertThat(ldaModel.topicTotals[0], is(equalTo(currentTopicTotals - 1)));
     }
 
     @Test
-    public void testGetTopicProbabilityWorksCorrectlySimpleCase() {
+    public void testGetTopicWeightWorksCorrectlySimpleCase() {
         ldaModel = new LDAModel(2);
         documents.clear();
         documents.add(Arrays.asList(document1));
         ldaModel.readDocuments(documents);
         ldaModel.initialize();
 
-        ldaModel.topicDocumentCount[0][0] = 0;
-        ldaModel.topicDocumentCount[1][0] = 0;
+        ldaModel.documentTopicCount[0][0] = 0;
+        ldaModel.documentTopicCount[0][1] = 0;
 
         ldaModel.wordTopicCount[0][0] = 0;
         ldaModel.wordTopicCount[0][1] = 0;
@@ -174,7 +174,7 @@ public class LDAModelTest {
         ldaModel.addTopicToWord(0, 3, 3, 1);
         ldaModel.addTopicToWord(0, 4, 4, 1);
 
-        assertThat(ldaModel.getTopicWeight(0, 0, 0), is(equalTo(1.1666666666666667)));
+        assertThat(ldaModel.getTopicWeight(ldaModel.documentTopicCount[0][0], 0, 0), is(equalTo(1.1666666666666667)));
     }
 
     @Test
@@ -185,8 +185,8 @@ public class LDAModelTest {
         ldaModel.readDocuments(documents);
         ldaModel.initialize();
 
-        ldaModel.topicDocumentCount[0][0] = 0;
-        ldaModel.topicDocumentCount[1][0] = 0;
+        ldaModel.documentTopicCount[0][0] = 0;
+        ldaModel.documentTopicCount[0][1] = 0;
 
         ldaModel.wordTopicCount[0][0] = 0;
         ldaModel.wordTopicCount[0][1] = 0;
@@ -208,7 +208,7 @@ public class LDAModelTest {
         ldaModel.addTopicToWord(0, 3, 3, 0);
         ldaModel.addTopicToWord(0, 4, 4, 0);
 
-        assertThat(ldaModel.getNewTopic(0, 0), is(equalTo(0)));
+        assertThat(ldaModel.getNewTopic(0, ldaModel.documentTopicCount[0]), is(equalTo(0)));
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -496,9 +496,9 @@ public class LDAModelTest {
         ldaModel.readDocuments(documents);
         ldaModel.initialize();
 
-        ldaModel.topicDocumentCount[0][0] = 4;
-        ldaModel.topicDocumentCount[1][0] = 9;
-        ldaModel.topicDocumentCount[2][0] = 2;
+        ldaModel.documentTopicCount[0][0] = 4;
+        ldaModel.documentTopicCount[0][1] = 9;
+        ldaModel.documentTopicCount[0][2] = 2;
 
         double [] expected = {0.2727272727272727, 0.5757575757575758, 0.15151515151515152};
 

--- a/src/test/java/nlmt/topicmodels/LDAModelTest.java
+++ b/src/test/java/nlmt/topicmodels/LDAModelTest.java
@@ -573,6 +573,19 @@ public class LDAModelTest {
         }
 
         double [] probabilities = ldaModel.inference(unseenDocument, 100);
-        assertThat(probabilities[matchingTopicIndex] > 0.8, is(true));
+        assertThat(probabilities[matchingTopicIndex] > 0.7, is(true));
+    }
+
+    @Test
+    public void testInferenceNoWordsMatchGlobalVocabulary() {
+        ldaModel = new LDAModel(10, 1.0, 0.1);
+        ldaModel.readDocuments(generateTestDocuments());
+        ldaModel.doGibbsSampling(300);
+
+        String [] unseenWords = {"za", "zb", "zc", "zd", "ze"};
+        double [] expectedProbabilities = new double[10];
+
+        double [] probabilities = ldaModel.inference(Arrays.asList(unseenWords), 100);
+        assertThat(probabilities, is(equalTo(expectedProbabilities)));
     }
 }

--- a/src/test/java/nlmt/topicmodels/LDAModelTest.java
+++ b/src/test/java/nlmt/topicmodels/LDAModelTest.java
@@ -539,47 +539,4 @@ public class LDAModelTest {
         double [] expected = {0.0, 0.0, 0.0};
         assertThat(ldaModel.inference(noGlobalWords, 100), is(equalTo(expected)));
     }
-
-    @Test
-    public void testInferenceDocumentDistributedEquallyBetweenTwoTopics() {
-        ldaModel = new LDAModel(2, 1.0, 0.1);
-        documents.clear();
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic2));
-        ldaModel.readDocuments(documents);
-        ldaModel.doGibbsSampling(100);
-
-        List<String> twoWords = new ArrayList<>();
-        twoWords.add("1");
-        twoWords.add("2");
-        double [] expected = {0.5, 0.5};
-        assertThat(ldaModel.inference(twoWords, 100), is(equalTo(expected)));
-    }
-
-    @Test
-    public void testInferenceDocumentAllOneTopic() {
-        ldaModel = new LDAModel(2, 1.0, 0.1);
-        documents.clear();
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic1));
-        documents.add(Arrays.asList(topic2));
-        ldaModel.readDocuments(documents);
-        ldaModel.doGibbsSampling(200);
-
-        List<String> twoWords = new ArrayList<>();
-        twoWords.add("1");
-        twoWords.add("1");
-        twoWords.add("1");
-
-        List<List<String>> topWords = ldaModel.getTopics(1);
-        double [] expected = {1.0, 0.0};
-        if (topWords.get(1).get(0).equals("1")) {
-            expected = new double[] {0.0, 1.0};
-        }
-        assertThat(ldaModel.inference(twoWords, 100), is(equalTo(expected)));
-    }
 }

--- a/src/test/java/nlmt/topicmodels/VocabularyTest.java
+++ b/src/test/java/nlmt/topicmodels/VocabularyTest.java
@@ -67,6 +67,28 @@ public class VocabularyTest {
     }
 
     @Test
+    public void testContainsInEmptyVocabularyWorksCorrectly() {
+        assertThat(vocabulary.contains("not"), is(equalTo(false)));
+    }
+
+    @Test
+    public void testContainsInPopulatedVocabularyWorksCorrectly() {
+        vocabulary.addWord("some");
+        vocabulary.addWord("words");
+        assertThat(vocabulary.contains("some"), is(equalTo(true)));
+        assertThat(vocabulary.contains("words"), is(equalTo(true)));
+        assertThat(vocabulary.contains("not"), is(equalTo(false)));
+    }
+
+    @Test
+    public void testContainsCaseSensitive() {
+        vocabulary.addWord("some");
+        vocabulary.addWord("words");
+        assertThat(vocabulary.contains("SOME"), is(equalTo(false)));
+        assertThat(vocabulary.contains("WORDS"), is(equalTo(false)));
+    }
+
+    @Test
     public void testGetWordFromIndexReturnsEmptyOnNegativeIndex() {
         assertThat(vocabulary.getWordFromIndex(-100), is(equalTo("")));
     }


### PR DESCRIPTION
Adds ability to infer the topic distribution of a previously unseen document. Words in the new document not appearing in the global vocabulary are ignored. The result of the function is an array containing the topic distributions.