### PR TITLE
Prevent new words from entering vocabulary

### DIFF
--- a/src/main/java/nlmt/datatypes/Document.java
+++ b/src/main/java/nlmt/datatypes/Document.java
@@ -46,14 +46,20 @@ public class Document implements Serializable
      * Each document is a List of Strings that represent the
      * words in the document. For each word, add it to the vocabulary,
      * and then add the vocabulary number assigned to the word to
-     * the wordArray for the document.
+     * the wordArray for the document. If <code>addWordsToVocabulary</code> is
+     * <code>true</code>, then any previously unseen words will be added to
+     * the vocabulary.
      *
      * @param words the list of words in the document
+     * @param addWordsToVocabulary if true, then previously unseen words will be added to the vocabulary
      */
-    public void readDocument(List<String> words) {
+    public void readDocument(List<String> words, boolean addWordsToVocabulary) {
         for (String word : words) {
-            vocabulary.addObject(word);
-            wordArray.add(new Word(word, vocabulary.getIndexFromObject(word)));
+            boolean vocabularyContainsWord = vocabulary.contains(word);
+            if ((vocabularyContainsWord) || (!vocabularyContainsWord && addWordsToVocabulary)) {
+                vocabulary.addObject(word);
+                wordArray.add(new Word(word, vocabulary.getIndexFromObject(word)));
+            }
         }
     }
 

--- a/src/main/java/nlmt/datatypes/SparseDocument.java
+++ b/src/main/java/nlmt/datatypes/SparseDocument.java
@@ -45,16 +45,22 @@ public class SparseDocument implements Serializable
      * Each document is a List of Strings that represent the
      * words in the document. For each word, add it to the vocabulary,
      * and then add the vocabulary number assigned to the word to
-     * the wordArray for the document.
+     * the wordArray for the document. If <code>addWordsToVocabulary</code>
+     * is <code>true</code>, then previously unseen vocabulary words will be
+     * added to the vocabulary.
      *
      * @param words the list of words in the document
+     * @param addWordsToVocabulary if true, then previously unseen vocabulary words will be added to the vocabulary
      */
-    public void readDocument(List<String> words) {
+    public void readDocument(List<String> words, boolean addWordsToVocabulary) {
         Map<String, Long> wordCounts = words.stream().collect(Collectors.groupingBy(e -> e, Collectors.counting()));
-        for (String key : wordCounts.keySet()) {
-            Word newWord = new Word(key, vocabulary.addObject(key));
-            newWord.setTotalCount(wordCounts.get(key).intValue());
-            wordMap.put(newWord.getVocabularyId(), newWord);
+        for (String word : wordCounts.keySet()) {
+            boolean vocabularyContainsWord = vocabulary.contains(word);
+            if ((vocabularyContainsWord) || (!vocabularyContainsWord && addWordsToVocabulary)) {
+                Word newWord = new Word(word, vocabulary.addObject(word));
+                newWord.setTotalCount(wordCounts.get(word).intValue());
+                wordMap.put(newWord.getVocabularyId(), newWord);
+            }
         }
     }
 

--- a/src/main/java/nlmt/topicmodels/LDAModel.java
+++ b/src/main/java/nlmt/topicmodels/LDAModel.java
@@ -99,7 +99,7 @@ public class LDAModel implements Serializable
 
     /**
      * Read in a list of documents. Each document is assumed to be a
-     * list of Strings. Stopwords and other pre-processing should be
+     * list of Strings. Stop-words and other pre-processing should be
      * done prior to reading documents. The documents should be read before
      * running doGibbsSampling.
      *
@@ -110,7 +110,7 @@ public class LDAModel implements Serializable
 
         for (int i = 0; i < documents.size(); i++) {
             this.documents[i] = new Document(vocabulary);
-            this.documents[i].readDocument(documents.get(i));
+            this.documents[i].readDocument(documents.get(i), true);
         }
     }
 
@@ -309,7 +309,7 @@ public class LDAModel implements Serializable
         }
 
         Document newDocument = new Document(vocabulary);
-        newDocument.readDocument(document);
+        newDocument.readDocument(document, false);
         int [] localTopicDocumentCount = new int[numTopics];
         int [] words = newDocument.getWordArray();
 
@@ -327,13 +327,11 @@ public class LDAModel implements Serializable
         for (int iteration = 0; iteration < numIterations; iteration++) {
             int [] topics = newDocument.getTopicArray();
             for (int wordIndexInDoc = 0; wordIndexInDoc < words.length; wordIndexInDoc++) {
-                if (words[wordIndexInDoc] < wordTopicCount.length) {
-                    localTopicDocumentCount[topics[wordIndexInDoc]]--;
-                    newDocument.setTopicForWord(wordIndexInDoc, -1);
-                    int newTopic = getNewTopic(words[wordIndexInDoc], localTopicDocumentCount);
-                    newDocument.setTopicForWord(wordIndexInDoc, newTopic);
-                    localTopicDocumentCount[newTopic]++;
-                }
+                localTopicDocumentCount[topics[wordIndexInDoc]]--;
+                newDocument.setTopicForWord(wordIndexInDoc, -1);
+                int newTopic = getNewTopic(words[wordIndexInDoc], localTopicDocumentCount);
+                newDocument.setTopicForWord(wordIndexInDoc, newTopic);
+                localTopicDocumentCount[newTopic]++;
             }
         }
 

--- a/src/test/java/nlmt/datatypes/DocumentTest.java
+++ b/src/test/java/nlmt/datatypes/DocumentTest.java
@@ -76,12 +76,12 @@ public class DocumentTest {
     @Test
     public void testDocumentEqualityDifferentVocabulariesReturnsFalse() {
         document = new Document(vocabulary);
-        document.readDocument(simpleDocument);
+        document.readDocument(simpleDocument, true);
 
         IdentifierObjectMapper<String> vocabulary1 = new IdentifierObjectMapper<>();
         vocabulary1.addObject("something");
         Document document1 = new Document(vocabulary1);
-        document1.readDocument(simpleDocument);
+        document1.readDocument(simpleDocument, true);
 
         assertThat(document.equals(document1), is(false));
         assertThat(document.hashCode() == document1.hashCode(), is(false));
@@ -90,10 +90,10 @@ public class DocumentTest {
     @Test
     public void testDocumentEqualitySameVocabulariesReturnsTrue() {
         document = new Document(vocabulary);
-        document.readDocument(simpleDocument);
+        document.readDocument(simpleDocument, true);
 
         Document document1 = new Document(vocabulary);
-        document1.readDocument(simpleDocument);
+        document1.readDocument(simpleDocument, true);
 
         assertThat(document.equals(document1), is(true));
         assertThat(document.hashCode() == document1.hashCode(), is(true));
@@ -102,12 +102,12 @@ public class DocumentTest {
     @Test
     public void testDocumentEqualitySameVocabulariesDifferentWordsReturnsTrue() {
         document = new Document(vocabulary);
-        document.readDocument(simpleDocument);
+        document.readDocument(simpleDocument, true);
 
         Document document1 = new Document(vocabulary);
         List<String> differentDocument = new ArrayList<>();
         differentDocument.add("different");
-        document1.readDocument(differentDocument);
+        document1.readDocument(differentDocument, false);
 
         assertThat(document.equals(document1), is(false));
         assertThat(document.hashCode() == document1.hashCode(), is(false));
@@ -116,7 +116,7 @@ public class DocumentTest {
     @Test
     public void testReadDocumentAddsWordsToVocabulary() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         assertThat(vocabulary.getIndexFromObject("the"), is(not(equalTo(-1))));
         assertThat(vocabulary.getIndexFromObject("cat"), is(not(equalTo(-1))));
         assertThat(vocabulary.getIndexFromObject("sat"), is(not(equalTo(-1))));
@@ -131,7 +131,7 @@ public class DocumentTest {
     @Test
     public void testReadDocumentAddsWordsToWordArray() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         int theIndex = vocabulary.getIndexFromObject("the");
         int catIndex = vocabulary.getIndexFromObject("cat");
         int satIndex = vocabulary.getIndexFromObject("sat");
@@ -142,14 +142,14 @@ public class DocumentTest {
     @Test
     public void testGetRawWordsWorksCorrectly() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         assertThat(document.getRawWords(), is(equalTo(words)));
     }
 
     @Test
     public void testTopicArrayAllNegativeOnesWhenDocumentRead() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         int [] expectedTopicArrayArray = {-1, -1, -1};
         assertThat(document.getTopicArray(), is(equalTo(expectedTopicArrayArray)));
     }
@@ -157,7 +157,7 @@ public class DocumentTest {
     @Test
     public void testTopicArraySetSingleCorrectly() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         document.setTopicForWord(0, 1);
         int [] expectedTopicArrayArray = {1, -1, -1};
         assertThat(document.getTopicArray(), is(equalTo(expectedTopicArrayArray)));
@@ -166,7 +166,7 @@ public class DocumentTest {
     @Test
     public void testTopicArraySetAllCorrectly() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         document.setTopicForWord(0, 1);
         document.setTopicForWord(1, 2);
         document.setTopicForWord(2, 3);
@@ -177,14 +177,14 @@ public class DocumentTest {
     @Test(expected=IllegalArgumentException.class)
     public void testSetTopicOnNegativeWordIndexThrowsException() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         document.setTopicForWord(-1, 1);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testSetTopicOnWordIndexTooLargeThrowsException() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         document.setTopicForWord(3, 1);
     }
 
@@ -197,7 +197,7 @@ public class DocumentTest {
     public void testGetWordsOnDocumentAllSameWord() {
         String [] words = {"the", "the", "the"};
         int [] vocabList = {0, 0, 0};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         assertThat(document.getWordArray().length, is(equalTo(3)));
         assertThat(document.getWordArray(), is(equalTo(vocabList)));
         assertThat(document.getRawWords(), is(equalTo(words)));
@@ -206,7 +206,7 @@ public class DocumentTest {
     @Test
     public void testClearTopicsWorksCorrectly() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         document.setTopicForWord(0, 1);
         document.setTopicForWord(1, 2);
         document.setTopicForWord(2, 3);
@@ -218,7 +218,7 @@ public class DocumentTest {
     @Test
     public void testGetWordSetWorksCorrectly() {
         String [] words = {"the", "cat", "sat"};
-        document.readDocument(Arrays.asList(words));
+        document.readDocument(Arrays.asList(words), true);
         Set<Integer> expected = new HashSet<>();
         expected.add(0);
         expected.add(1);
@@ -227,10 +227,30 @@ public class DocumentTest {
     }
 
     @Test
+    public void testReadDocumentVocabularyWordsOnlyDoesNotAddWordsToDocument() {
+        String [] words = {"the", "cat", "sat"};
+        document.readDocument(Arrays.asList(words), false);
+        Set<Integer> expected = new HashSet<>();
+        assertThat(document.getWordSet(), is(equalTo(expected)));
+    }
+
+    @Test
+    public void testReadDocumentVocabularyWordsOnlyAddsSomeWordsToDocument() {
+        String [] words = {"the", "cat", "sat"};
+        vocabulary.addObject("the");
+        vocabulary.addObject("sat");
+        document.readDocument(Arrays.asList(words), false);
+        Set<Integer> expected = new HashSet<>();
+        expected.add(vocabulary.getIndexFromObject("the"));
+        expected.add(vocabulary.getIndexFromObject("sat"));
+        assertThat(document.getWordSet(), is(equalTo(expected)));
+    }
+
+    @Test
     public void testSerializationRoundTrip() {
         List<String> documentList = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         document = new Document(vocabulary);
-        document.readDocument(documentList);
+        document.readDocument(documentList, false);
         try {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);

--- a/src/test/java/nlmt/datatypes/SparseDocumentTest.java
+++ b/src/test/java/nlmt/datatypes/SparseDocumentTest.java
@@ -16,6 +16,7 @@
 
 package nlmt.datatypes;
 
+import org.hamcrest.core.IsEqual;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -70,12 +71,12 @@ public class SparseDocumentTest
     @Test
     public void testDocumentEqualityDifferentVocabulariesReturnsFalse() {
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(simpleDocument);
+        sparseDocument.readDocument(simpleDocument, true);
 
         IdentifierObjectMapper<String> vocabulary1 = new IdentifierObjectMapper<>();
         vocabulary1.addObject("something");
         SparseDocument sparseDocument1 = new SparseDocument(vocabulary1);
-        sparseDocument1.readDocument(simpleDocument);
+        sparseDocument1.readDocument(simpleDocument, true);
 
         assertThat(sparseDocument.equals(sparseDocument1), is(false));
         assertThat(sparseDocument.hashCode() == sparseDocument1.hashCode(), is(false));
@@ -84,10 +85,10 @@ public class SparseDocumentTest
     @Test
     public void testDocumentEqualitySameVocabulariesReturnsTrue() {
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(simpleDocument);
+        sparseDocument.readDocument(simpleDocument, true);
 
         SparseDocument sparseDocument1 = new SparseDocument(vocabulary);
-        sparseDocument1.readDocument(simpleDocument);
+        sparseDocument1.readDocument(simpleDocument, true);
 
         assertThat(sparseDocument.equals(sparseDocument1), is(true));
         assertThat(sparseDocument.hashCode() == sparseDocument1.hashCode(), is(true));
@@ -96,12 +97,12 @@ public class SparseDocumentTest
     @Test
     public void testDocumentEqualitySameVocabulariesDifferentWordsReturnsTrue() {
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(simpleDocument);
+        sparseDocument.readDocument(simpleDocument, true);
 
         SparseDocument sparseDocument1 = new SparseDocument(vocabulary);
         List<String> differentDocument = new ArrayList<>();
         differentDocument.add("different");
-        sparseDocument1.readDocument(differentDocument);
+        sparseDocument1.readDocument(differentDocument, true);
 
         assertThat(sparseDocument.equals(sparseDocument1), is(false));
         assertThat(sparseDocument.hashCode() == sparseDocument1.hashCode(), is(false));
@@ -112,7 +113,7 @@ public class SparseDocumentTest
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         Set<String> expectedWords = new HashSet<>(Arrays.asList("wordOne", "wordTwo", "wordThree"));
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         assertThat(sparseDocument.getWordSet().stream().map(Word::getRawWord).collect(Collectors.toSet()), is(equalTo(expectedWords)));
         assertThat(sparseDocument.getWordCount(vocabulary.getIndexFromObject("wordOne")), is(equalTo(1)));
         assertThat(sparseDocument.getWordCount(vocabulary.getIndexFromObject("wordTwo")), is(equalTo(1)));
@@ -123,7 +124,7 @@ public class SparseDocumentTest
     public void testSetTopicForWordSingleWordWorksCorrectly() {
         List<String> document = Arrays.asList("wordOne");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 31);
         assertThat(sparseDocument.getTopicForWord(vocabulary.getIndexFromObject("wordOne")), is(equalTo(31)));
     }
@@ -132,7 +133,7 @@ public class SparseDocumentTest
     public void testSetTopicForNonExistentWordDoesNothing() {
         List<String> document = Arrays.asList("wordOne");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 31);
         sparseDocument.setTopicForWord(1111, 2);
         assertThat(sparseDocument.getTopicForWord(vocabulary.getIndexFromObject("wordOne")), is(equalTo(31)));
@@ -142,7 +143,7 @@ public class SparseDocumentTest
     public void testGetTopicForNonExistentWordReturnsNegativeOne() {
         List<String> document = Arrays.asList("wordOne");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 31);
         assertThat(sparseDocument.getTopicForWord(1111), is(equalTo(-1)));
     }
@@ -151,7 +152,7 @@ public class SparseDocumentTest
     public void testGetCountForNonExistentWordReturnsZero() {
         List<String> document = Arrays.asList("wordOne");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         assertThat(sparseDocument.getWordCount(1111), is(equalTo(0)));
     }
 
@@ -159,7 +160,7 @@ public class SparseDocumentTest
     public void testGetTopicsWorksCorrectly() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 1);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
@@ -177,7 +178,7 @@ public class SparseDocumentTest
     public void testGetTopicCountsReturnsNegativeOneCountWhenNoTopicsAssigned() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         Map<Integer, Integer> expectedTopicCounts = new HashMap<>();
         expectedTopicCounts.put(-1, 3);
         assertThat(sparseDocument.getTopicCounts(), is(equalTo(expectedTopicCounts)));
@@ -187,7 +188,7 @@ public class SparseDocumentTest
     public void testGetTopicCountsWorksCorrectlyWhenTopicsAssigned() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 1);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
@@ -202,7 +203,7 @@ public class SparseDocumentTest
     public void testGetWordTopicCountWorksCorrectly() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 1);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
@@ -216,7 +217,7 @@ public class SparseDocumentTest
     public void testGetWordTopicCountEmptyOnNonExistentWord() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 1);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
@@ -229,7 +230,7 @@ public class SparseDocumentTest
     public void testGetWordTopicNegativeOneWhenNotInitialized() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
         Word word = new Word("wordOne", vocabulary.getIndexFromObject("wordOne"));
@@ -242,7 +243,7 @@ public class SparseDocumentTest
     public void testGetWordCountsByTopicCorrectlyWhenTopicsAssigned() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 1);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
@@ -255,7 +256,7 @@ public class SparseDocumentTest
     public void testGetWordCountsByTopicIsEmptyOnNonExistentTopic() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 1);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 3);
@@ -267,7 +268,7 @@ public class SparseDocumentTest
     public void testGetWordCountsByTopicMultipleWordsSameTopic() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, true);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordOne"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordTwo"), 2);
         sparseDocument.setTopicForWord(vocabulary.getIndexFromObject("wordThree"), 2);
@@ -279,10 +280,32 @@ public class SparseDocumentTest
     }
 
     @Test
+    public void testReadDocumentVocabularyWordsOnlyDoesNotAddWordsToDocument() {
+        String [] words = {"the", "cat", "sat"};
+        sparseDocument = new SparseDocument(vocabulary);
+        sparseDocument.readDocument(Arrays.asList(words), false);
+        Set<Integer> expected = new HashSet<>();
+        assertThat(sparseDocument.getWordSet(), is(IsEqual.equalTo(expected)));
+    }
+
+    @Test
+    public void testReadDocumentVocabularyWordsOnlyAddsSomeWordsToDocument() {
+        String [] words = {"the", "cat", "sat"};
+        vocabulary.addObject("the");
+        vocabulary.addObject("sat");
+        sparseDocument = new SparseDocument(vocabulary);
+        sparseDocument.readDocument(Arrays.asList(words), false);
+        Set<Integer> expected = new HashSet<>();
+        expected.add(vocabulary.getIndexFromObject("the"));
+        expected.add(vocabulary.getIndexFromObject("sat"));
+        assertThat(sparseDocument.getWordSet().stream().map(Word::getVocabularyId).collect(Collectors.toSet()), is(IsEqual.equalTo(expected)));
+    }
+
+    @Test
     public void testSerializationRoundTrip() {
         List<String> document = Arrays.asList("wordOne", "wordTwo", "wordThree", "wordThree");
         sparseDocument = new SparseDocument(vocabulary);
-        sparseDocument.readDocument(document);
+        sparseDocument.readDocument(document, false);
         try {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);

--- a/src/test/java/nlmt/topicmodels/HierarchicalLDAModelTest.java
+++ b/src/test/java/nlmt/topicmodels/HierarchicalLDAModelTest.java
@@ -1027,6 +1027,79 @@ public class HierarchicalLDAModelTest {
     }
 
     @Test
+    public void testSingleWordDocumentInferenceWithUnseenWords() {
+        // We need equal probabilities of seeing a word at any level of the tree
+        // Control gamma so that no new nodes are really generated
+        hierarchicalLDAModel = new HierarchicalLDAModel(3, HierarchicalLDAModel.DEFAULT_GAMMA,
+                new double [] {0.1, 0.1, 2.0}, 0.99, 1.0);
+        List<List<String>> documentList = new ArrayList<>();
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document1));
+        documentList.add(Arrays.asList(document2));
+        documentList.add(Arrays.asList(document3));
+        hierarchicalLDAModel.readDocuments(documentList);
+        HierarchicalLDANode child0 = hierarchicalLDAModel.rootNode.spawnChild(1);
+        HierarchicalLDANode child1 = child0.spawnChild(2);
+        hierarchicalLDAModel.documents[0].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[1].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[2].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[3].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[4].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[5].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[6].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[7].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[8].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[9].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[10].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[11].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[12].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[13].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[14].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[15].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[16].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[17].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[18].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[19].getWordSet().forEach(child1::addWord);
+        hierarchicalLDAModel.documents[20].getWordSet().forEach(hierarchicalLDAModel.rootNode::addWord);
+        hierarchicalLDAModel.documents[21].getWordSet().forEach(hierarchicalLDAModel.rootNode::addWord);
+
+        List<String> testDocument = new ArrayList<>();
+        testDocument.add("does");
+        testDocument.add("not");
+        testDocument.add("exist");
+
+        List<Double> expectedDistributions = new ArrayList<>();
+        expectedDistributions.add(0.0);
+        expectedDistributions.add(0.0);
+        expectedDistributions.add(0.0);
+        List<Integer> expectedNodes = new ArrayList<>();
+        expectedNodes.add(-1);
+        expectedNodes.add(-1);
+        expectedNodes.add(-1);
+
+        Pair<List<Integer>, List<Double>> results = hierarchicalLDAModel.inference(testDocument, 10, true);
+        assertThat(results, is(equalTo(Pair.of(expectedNodes, expectedDistributions))));
+    }
+
+    @Test
     public void testGetHierarchyComplexExampleWorksCorrectly() {
         hierarchicalLDAModel = new HierarchicalLDAModel();
         hierarchicalLDAModel.rootNode = new HierarchicalLDANode(null, 1);        // node 0


### PR DESCRIPTION
As a fix for issue #21, when reading into a `Document` or `SparseDocument`, added a new switch called `addWordsToVocabulary` that will allow the caller to control whether previously unseen words should be added to the vocabulary. 